### PR TITLE
Add support for Ctrl, Tab, and Alt keys

### DIFF
--- a/packages/keybr-keyboard-ui/lib/custom/KeyDetails.tsx
+++ b/packages/keybr-keyboard-ui/lib/custom/KeyDetails.tsx
@@ -60,6 +60,28 @@ export function KeyDetails({
           </Value>
         </Field>
       </FieldList>
+      <FieldList>
+        <Field size={6}>
+          <Name>
+            <ModifierInfo modifier={KeyModifier.Ctrl} />
+          </Name>
+        </Field>
+        <Field size={10}>
+          <Value>
+            <CharacterInfo character={c} />
+          </Value>
+        </Field>
+        <Field size={6}>
+          <Name>
+            <ModifierInfo modifier={KeyModifier.Tab} />
+          </Name>
+        </Field>
+        <Field size={10}>
+          <Value>
+            <CharacterInfo character={d} />
+          </Value>
+        </Field>
+      </FieldList>
     </>
   );
 }

--- a/packages/keybr-keyboard-ui/lib/custom/LayoutTable.tsx
+++ b/packages/keybr-keyboard-ui/lib/custom/LayoutTable.tsx
@@ -25,6 +25,9 @@ export function LayoutTable() {
             <th className={styles.characterCol}>
               <ModifierInfo modifier={KeyModifier.ShiftAlt} />
             </th>
+            <th className={styles.characterCol}>
+              <ModifierInfo modifier={KeyModifier.Ctrl} />
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -45,6 +48,9 @@ export function LayoutTable() {
                 </td>
                 <td className={styles.characterCol}>
                   <CharacterInfo character={d} />
+                </td>
+                <td className={styles.characterCol}>
+                  <CharacterInfo character={c} />
                 </td>
               </tr>
             );

--- a/packages/keybr-keyboard-ui/lib/custom/LiveImport.tsx
+++ b/packages/keybr-keyboard-ui/lib/custom/LiveImport.tsx
@@ -16,6 +16,8 @@ export function LiveImport({
     code: string;
     shift: boolean;
     alt: boolean;
+    ctrl: boolean;
+    tab: boolean;
   } | null>(null);
   return (
     <FieldList>
@@ -34,7 +36,9 @@ export function LiveImport({
               const alt =
                 event.getModifierState("Alt") ||
                 event.getModifierState("AltGraph");
-              ref.current = { code, shift, alt };
+              const ctrl = event.getModifierState("Control");
+              const tab = event.getModifierState("Tab");
+              ref.current = { code, shift, alt, ctrl, tab };
             } else {
               ref.current = null;
             }
@@ -47,8 +51,8 @@ export function LiveImport({
               event.inputType === "insertText" &&
               event.data
             ) {
-              const { code, shift, alt } = lastKey;
-              const modifier = KeyModifier.from(shift, alt);
+              const { code, shift, alt, ctrl, tab } = lastKey;
+              const modifier = KeyModifier.from(shift, alt, ctrl, tab);
               const codePoint = event.data.codePointAt(0) ?? 0x0000;
               setLayout(layout.setOne(code, modifier, codePoint));
               setInputData({ key: code, codePoint, modifier });

--- a/packages/keybr-keyboard-ui/lib/custom/ModifierInfo.tsx
+++ b/packages/keybr-keyboard-ui/lib/custom/ModifierInfo.tsx
@@ -10,6 +10,10 @@ export function ModifierInfo({ modifier }: { readonly modifier: KeyModifier }) {
       return <span>AltGr</span>;
     case KeyModifier.ShiftAlt:
       return <span>Shift AltGr</span>;
+    case KeyModifier.Ctrl:
+      return <span>Ctrl</span>;
+    case KeyModifier.Tab:
+      return <span>Tab</span>;
   }
   return null;
 }


### PR DESCRIPTION
Fixes #1

Add support for `Ctrl` and `Tab` keys in various components.

* **KeyDetails.tsx**: Add support for `Ctrl` and `Tab` keys by including `ModifierInfo` and `CharacterInfo` components for these keys.
* **LayoutTable.tsx**: Add support for `Ctrl` key by including `ModifierInfo` and `CharacterInfo` components for this key.
* **LiveImport.tsx**: Add support for `Ctrl` and `Tab` keys by updating the `ref` object and handling their states in event listeners.
* **ModifierInfo.tsx**: Add cases for `Ctrl` and `Tab` keys to return appropriate span elements.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rytina/keybr.com/pull/2?shareId=3b77ce0d-6b17-4d9c-b19f-4fd0e6f1725a).